### PR TITLE
Fixing derived attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,9 +10,9 @@ default['octopus']['tentacle']['environment'] = node.chef_environment
 
 # Octopus Tools attributes
 default['octopus']['tools']['version'] = "2.5.10.39"
-default['octopus']['tools']['url'] = "http://download.octopusdeploy.com/octopus-tools/#{node['octopus']['tools']['version']}/OctopusTools.#{node['octopus']['tools']['version']}.zip"
+default['octopus']['tools']['url'] = "http://download.octopusdeploy.com/octopus-tools/%{version}/OctopusTools.%{version}.zip"
 default['octopus']['tools']['checksum'] = "0790ed04518e0b50f3000093b4a2b4ad47f0f5c9af269588e82d960813abfd67"
-default['octopus']['tools']['home'] = "C:\\tools\\OctopusTools.#{node['octopus']['tools']['version']}"
+default['octopus']['tools']['home'] = "C:\\tools\\OctopusTools.%{version}"
 
 # replace with your octopus server thumbprint
 default['octopus']['server']['thumbprint'] = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -22,9 +22,9 @@ default['octopus']['api']['uri'] = "http://my-octopus-server.com/api"
 default['octopus']['api']['key'] = "API-XXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 if node['kernel']['machine'] =~ /x86_64/
-  default['octopus']['tentacle']['url'] = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.#{node['octopus']['tentacle']['version']}-x64.msi"
+  default['octopus']['tentacle']['url'] = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.%{version}-x64.msi"
   default['octopus']['tentacle']['checksum'] = "cb81f5296f7843c5c04cb20a02793bb14dad50f6453a0f264ebe859e268d8289"
 else
-  default['octopus']['tentacle']['url'] = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.#{node['octopus']['tentacle']['version']}.msi"
+  default['octopus']['tentacle']['url'] = "https://download.octopusdeploy.com/octopus/Octopus.Tentacle.%{version}.msi"
   default['octopus']['tentacle']['checksum'] = "725222257424115455b4b8e38584aa5112e3be93bb30fea9345544e4ab7a2555"
 end

--- a/recipes/install_tentacle.rb
+++ b/recipes/install_tentacle.rb
@@ -24,7 +24,7 @@ tools = node['octopus']['tools']
 
 # download and install the tentacle service
 windows_package tentacle['package_name'] do
-  source tentacle['url']
+  source tentacle['url'] % { version: node['octopus']['tentacle']['version'] }
   checksum tentacle['checksum']
   options "INSTALLLOCATION=\"#{tentacle['install_dir']}\""
   action :install
@@ -34,8 +34,8 @@ octo_exe_path = win_friendly_path("#{tools['home']}/octo.exe")
 
 # download and unzip octopus tools
 windows_zipfile tools['home'] do
-  source tools['url']
+  source tools['url'] % { version: node['octopus']['tools']['version'] }
   checksum tools['checksum']
   action :unzip
-  not_if { ::File.exists?(octo_exe_path) } 
+  not_if { ::File.exists?(octo_exe_path) }
 end


### PR DESCRIPTION
### Issue:

When the attributes `node['octopus']['tentacle']['version']` or `node['octopus']['tools']['version']` are overridden in a wrapper cookbook the derived `url` attribute still keeps its old value. 
This happens because the way Chef evaluate the attributes.
### Fix:

Delaying the evaluation of those attributes to make the cookbook reusable or wrappable. 

More information:
https://coderanger.net/derived-attributes/
