### PR TITLE
Configure Tentacle on the server

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,20 +1,21 @@
-default['octopus']['tentacle']['url'] = "http://download.octopusdeploy.com/octopus/Octopus.Tentacle.2.6.0.778-x64.msi"
-default['octopus']['tentacle']['checksum'] = "cb81f5296f7843c5c04cb20a02793bb14dad50f6453a0f264ebe859e268d8289"
-default['octopus']['tentacle']['package_name'] = "Octopus Deploy Tentacle"
-default['octopus']['tentacle']['install_dir'] = "C:\\Program Files\\Octopus Deploy\\Tentacle"
-default['octopus']['tentacle']['port'] = "10933"
-default['octopus']['tentacle']['home'] = "C:\\Octopus"
-default['octopus']['tentacle']['role'] = "webserver"
-default['octopus']['tentacle']['name'] = "Tentacle"
-default['octopus']['tentacle']['environment'] = "Test"
+default['octopus']['tentacle']['url'] = 'http://download.octopusdeploy.com/octopus/Octopus.Tentacle.2.6.0.778-x64.msi'
+default['octopus']['tentacle']['checksum'] = 'cb81f5296f7843c5c04cb20a02793bb14dad50f6453a0f264ebe859e268d8289'
+default['octopus']['tentacle']['package_name'] = 'Octopus Deploy Tentacle'
+default['octopus']['tentacle']['install_dir'] = 'C:\Program Files\Octopus Deploy\Tentacle'
+default['octopus']['tentacle']['port'] = '10933'
+default['octopus']['tentacle']['home'] = 'C:\Octopus'
+default['octopus']['tentacle']['role'] = 'webserver'
+default['octopus']['tentacle']['name'] = node['hostname']
+default['octopus']['tentacle']['publichostname'] = node['fqdn']
+default['octopus']['tentacle']['environment'] = 'Test'
 
 # replace with your octopus server thumbprint
-default['octopus']['server']['thumbprint'] = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+default['octopus']['server']['thumbprint'] = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
-default['octopus']['tools']['url'] = "http://download.octopusdeploy.com/octopus-tools/2.5.10.39/OctopusTools.2.5.10.39.zip"
-default['octopus']['tools']['checksum'] = "0790ed04518e0b50f3000093b4a2b4ad47f0f5c9af269588e82d960813abfd67"
-default['octopus']['tools']['home'] = "C:\\tools\\OctopusTools.2.5.10.39"
+default['octopus']['tools']['url'] = 'http://download.octopusdeploy.com/octopus-tools/2.5.10.39/OctopusTools.2.5.10.39.zip'
+default['octopus']['tools']['checksum'] = '0790ed04518e0b50f3000093b4a2b4ad47f0f5c9af269588e82d960813abfd67'
+default['octopus']['tools']['home'] = 'C:\tools\OctopusTools.2.5.10.39'
 
 # replace with your octopus server api endpoint and key
-default['octopus']['api']['uri'] = "http://my-octopus-server.com/api"
-default['octopus']['api']['key'] = "API-XXXXXXXXXXXXXXXXXXXXXXXXXXX"
+default['octopus']['api']['uri'] = 'http://my-octopus-server.com/api'
+default['octopus']['api']['key'] = 'API-XXXXXXXXXXXXXXXXXXXXXXXXXXX'

--- a/recipes/create_environment.rb
+++ b/recipes/create_environment.rb
@@ -11,6 +11,6 @@
 powershell_script "create_tentacle_environment" do
 	code <<-EOH
 	Set-Alias octo "#{node['octopus']['tools']['home']}\\Octo.exe"
-	octo create-environment --name #{node['octopus']['tentacle']['environment']} --ignoreIfExists --server=#{node['octopus']['api']['uri']} --apiKey=#{node['octopus']['api']['key']}
+	octo create-environment --name "#{node['octopus']['tentacle']['environment']}" --ignoreIfExists --server=#{node['octopus']['api']['uri']} --apiKey=#{node['octopus']['api']['key']}
 	EOH
 end

--- a/recipes/create_team.rb
+++ b/recipes/create_team.rb
@@ -1,0 +1,96 @@
+#
+# Cookbook Name:: octopus
+# Recipe:: register_tentacle
+#
+# Author:: Michael Burns (<michael.burns@shawmedia.ca>)
+#
+# Copyright 2014-2015, Shaw Media Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+tentacle = node['octopus']['tentacle']
+server = node['octopus']['server']
+api = node['octopus']['api']
+
+# register the tentacle with octopus server
+
+octoposhPath = "#{Chef::Config['file_cache_path']}/octoposh.ps1"
+
+template octoposhPath do
+  source 'octoposh.ps1.erb'
+end
+
+
+powershell_script 'create_octopus_team_if_not_exists' do
+	guard_interpreter :powershell_script
+	code <<-EOH3
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	. "#{octoposhPath}"
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$teamName = '#{node['octopus']['team']['name']}'	
+	$teamRoles = @('#{node['octopus']['team']['roles'].join(',')}') -split ',' | %{$_.Trim()} |?{$_}	
+	$teamEnvironments = @('#{node['octopus']['team']['environments'].join(',')}') -split ',' | %{$_.Trim()} |?{$_}	
+	$can_be_deleted = '#{node['octopus']['team']['can_be_deleted']}'	
+	$can_be_renamed = '#{node['octopus']['team']['can_be_renamed']}'
+	$can_change_roles = '#{node['octopus']['team']['can_change_roles']}'
+	$can_change_members = '#{node['octopus']['team']['can_change_members']}'
+	
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
+	
+	$team = Get-OctopusResourceModel -Resource Team
+    $team.Name = $teamName 
+
+    $team.UserRoleIds  = New-Object Octopus.Client.Model.ReferenceCollection
+	$teamRoles | %{
+		$team.UserRoleIds.Add($_)
+	}
+    
+    $team.CanBeDeleted=$can_be_deleted
+    $team.CanBeRenamed=$can_be_renamed
+    $team.CanChangeRoles=$can_change_roles
+    $team.CanChangeMembers=$can_change_members
+    $team.EnvironmentIds= New-Object Octopus.Client.Model.ReferenceCollection
+	
+	$teamEnvironments  | %{
+		$environment = Get-OctopusEnvironment -EnvironmentName $_
+		$team.EnvironmentIds.Add($environment.Id)
+	}    
+
+    New-OctopusResource -Resource $team
+	EOH3
+    only_if <<-EOH4
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	. "#{octoposhPath}"
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$teamName = '#{node['octopus']['team']['name']}'
+	
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey | out-null
+	
+	Try{$existingTeam =  Get-OctopusTeam -Name $teamName }Catch{$existingTeam=$null}
+	
+	if ($existingTeam){
+		return $false
+	} else {
+		return $true
+	}
+    EOH4
+end

--- a/recipes/create_team.rb
+++ b/recipes/create_team.rb
@@ -1,10 +1,9 @@
 #
 # Cookbook Name:: octopus
-# Recipe:: register_tentacle
+# Recipe:: create_team
 #
-# Author:: Michael Burns (<michael.burns@shawmedia.ca>)
+# Author:: Ivan Marx
 #
-# Copyright 2014-2015, Shaw Media Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +21,6 @@
 tentacle = node['octopus']['tentacle']
 server = node['octopus']['server']
 api = node['octopus']['api']
-
-# register the tentacle with octopus server
 
 octoposhPath = "#{Chef::Config['file_cache_path']}/octoposh.ps1"
 

--- a/recipes/register_environment_tentacle.rb
+++ b/recipes/register_environment_tentacle.rb
@@ -40,6 +40,7 @@ powershell_script 'register_tentacle_in_environment_if_not_there' do
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
 	$environments = '#{node['octopus']['environment'].to_json}' | ConvertFrom-Json			
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey | out-null
 	
 	foreach($environmentProp in $environments.psobject.Properties)
 	{
@@ -75,6 +76,7 @@ powershell_script 'register_tentacle_in_environment_if_not_there' do
 	$environments = '#{node['octopus']['environment'].to_json}' | ConvertFrom-Json			
 	
 	$machineChanged = $false
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey | out-null
 
 	foreach($environmentProp in $environments.psobject.Properties)
 	{

--- a/recipes/register_environment_tentacle.rb
+++ b/recipes/register_environment_tentacle.rb
@@ -1,10 +1,9 @@
 #
 # Cookbook Name:: octopus
-# Recipe:: register_tentacle
+# Recipe:: register_environment_tentacle
 #
-# Author:: Michael Burns (<michael.burns@shawmedia.ca>)
+# Author:: Ivan Marx
 #
-# Copyright 2014-2015, Shaw Media Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,8 +22,6 @@ tentacle = node['octopus']['tentacle']
 server = node['octopus']['server']
 api = node['octopus']['api']
 
-# register the tentacle with octopus server
-
 octoposhPath = "#{Chef::Config['file_cache_path']}/octoposh.ps1"
 
 template octoposhPath do
@@ -33,6 +30,7 @@ end
 
 
 powershell_script 'register_tentacle_in_environment_if_not_there' do	
+	guard_interpreter :powershell_script
 	code <<-EOH	
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
@@ -62,9 +60,38 @@ powershell_script 'register_tentacle_in_environment_if_not_there' do
 				if ($machineChanged) {
 						$machine | Update-OctopusResource -Force
 				}       
-
 			}
 		}
 	}		
 	EOH
+	only_if <<-EOH4
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	. "#{octoposhPath}"
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$environments = '#{node['octopus']['environment'].to_json}' | ConvertFrom-Json			
+	
+	$machineChanged = $false
+
+	foreach($environmentProp in $environments.psobject.Properties)
+	{
+			 Try{$environment = Get-OctopusEnvironment -Name $environmentProp.Name}Catch{$environment = $null}
+			 foreach($tentacle in $environmentProp.Value.tentacles)
+			 {
+					 Try{$machine = Get-OctopusMachine -Name $tentacle}Catch{$machine = $null}
+					 if($machine -ne $null -and $environment -ne $null)
+					 {                         
+
+							 if(-not $machine.Resource.EnvironmentIds.Contains($environment.Resource.Id))
+							 {
+									 $machineChanged =$true                                 
+							 }                         
+					 }
+			 }
+	}
+	return $machineChanged
+    EOH4
 end

--- a/recipes/register_environment_tentacle.rb
+++ b/recipes/register_environment_tentacle.rb
@@ -1,0 +1,70 @@
+#
+# Cookbook Name:: octopus
+# Recipe:: register_tentacle
+#
+# Author:: Michael Burns (<michael.burns@shawmedia.ca>)
+#
+# Copyright 2014-2015, Shaw Media Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+tentacle = node['octopus']['tentacle']
+server = node['octopus']['server']
+api = node['octopus']['api']
+
+# register the tentacle with octopus server
+
+octoposhPath = "#{Chef::Config['file_cache_path']}/octoposh.ps1"
+
+template octoposhPath do
+  source 'octoposh.ps1.erb'
+end
+
+
+powershell_script 'register_tentacle_in_environment_if_not_there' do	
+	code <<-EOH	
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	. "#{octoposhPath}"
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$environments = '#{node['octopus']['environment'].to_json}' | ConvertFrom-Json			
+	
+	foreach($environmentProp in $environments.psobject.Properties)
+	{
+		Try{$environment = Get-OctopusEnvironment -Name $environmentProp.Name}Catch{$environment = $null}
+		foreach($tentacle in $environmentProp.Value.tentacles)
+		{
+			Try{$machine = Get-OctopusMachine -Name $tentacle}Catch{$machine = $null}
+			if($machine -ne $null -and $environment -ne $null)
+			{
+				$machineChanged = $false
+
+				if(-not $machine.Resource.EnvironmentIds.Contains($environment.Resource.Id))
+				{
+					$machineChanged =$true
+					$machine.Resource.EnvironmentIds.Add($environment.Resource.Id)
+				}
+
+				if ($machineChanged) {
+						$machine | Update-OctopusResource -Force
+				}       
+
+			}
+		}
+	}		
+	EOH
+end

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -45,7 +45,7 @@ powershell_script "configure_tentacle_on_server" do
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
-	$machineName = '#{node['octopus']['tentacle']['name']}"'
+	$machineName = '#{node['octopus']['tentacle']['name']}'
 	$publicHostName = '#{node['octopus']['tentacle']['publichostname']}'
 	$port = '#{node['octopus']['tentacle']['port']}'
 	$expectedEnvironments = @('#{node['octopus']['tentacle']['environment']}') -split ',' | %{$_.Trim()} |?{$_}
@@ -127,7 +127,7 @@ powershell_script "configure_tentacle_on_server" do
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
-	$machineName = '#{node['octopus']['tentacle']['name']}"'
+	$machineName = '#{node['octopus']['tentacle']['name']}'
 	$publicHostName = '#{node['octopus']['tentacle']['publichostname']}'
 	$port = '#{node['octopus']['tentacle']['port']}'
 
@@ -160,7 +160,7 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
-	$machineName = '#{node['octopus']['tentacle']['name']}"'
+	$machineName = '#{node['octopus']['tentacle']['name']}'
 
 	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
 
@@ -175,7 +175,7 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
-	$machineName = '#{node['octopus']['tentacle']['name']}"'
+	$machineName = '#{node['octopus']['tentacle']['name']}'
 	
 	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
 	Try{$machine = Get-OctopusMachine -Name $machineName}Catch{$machine = $null}

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -118,7 +118,7 @@ powershell_script 'configure_tentacle_on_server' do
 		New-OctopusResource -Resource $machine
 	}
 	EOH
-    not_if <<-EOH
+    not_if <<-EOH2
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
@@ -156,12 +156,12 @@ powershell_script 'configure_tentacle_on_server' do
 	} else {
 		return $false
 	}
-    EOH	
+    EOH2
 end
 
 powershell_script 'configure_tentacle_with_latest_calamari' do
 	guard_interpreter :powershell_script
-	code <<-EOH
+	code <<-EOH3
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
@@ -174,9 +174,9 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
 
 	Start-OctopusCalamariUpdate -MachineName $machineName -Wait -Force
-	EOH
+	EOH3
 	action :run
-    not_if <<-EOH
+    not_if <<-EOH4
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
@@ -194,5 +194,5 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 	} else {
 		return $false
 	}
-    EOH
+    EOH4
 end

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -34,7 +34,7 @@ powershell_script "configure_tentacle_on_server" do
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
-	#{octoposhPath}
+	. "#{octoposhPath}"
 
 	Function Get-CurrentTentacleThumbprint
 	{
@@ -104,7 +104,7 @@ powershell_script "configure_tentacle_on_server" do
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
-	#{octoposhPath}
+	. "#{octoposhPath}"
 
 	Function Get-CurrentTentacleThumbprint
 	{
@@ -139,7 +139,7 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
-	#{octoposhPath}
+	. "#{octoposhPath}"
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
@@ -154,7 +154,7 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'
 	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
-	#{octoposhPath}
+	. "#{octoposhPath}"
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -70,20 +70,24 @@ powershell_script "configure_tentacle_on_server" do
 	if ($machine) {
 		$machineChanged = $false
 
-		if ($expectedThumbprint -ne $machine.Resource.Thumbprint) {
+		if ($expectedThumbprint -ne $machine.Resource.EndPoint.Thumbprint) {
 			write-host "Update machine to use new thumbprint $expectedThumbprint"
+			$machine.Resource.EndPoint.Thumbprint = $expectedThumbprint
 			$machine.Resource.Thumbprint = $expectedThumbprint
+			$machine.Thumbprint = $expectedThumbprint
 			$machineChanged = $true
 		}
 
-		if ($expectedUri -ne $machine.Resource.Uri) {
+		if ($expectedUri -ne $machine.Resource.EndPoint.Uri) {
 			write-host "Update machine to use new Uri $expectedUri"
+			$machine.Resource.EndPoint.Uri = $expectedUri
 			$machine.Resource.Uri = $expectedUri
+			$machine.Uri = $expectedUri
 			$machineChanged = $true
 		}
 
 		if ($machineChanged) {
-			$machine | Update-OctopusResource
+			$machine | Update-OctopusResource -Force
 		}
 	} else {
 		#Create an instance of a Machine Object
@@ -133,9 +137,9 @@ powershell_script "configure_tentacle_on_server" do
 	if ($machine) {
 		$expectedThumbprint = Get-CurrentTentacleThumbprint
 		$expectedUri = "https://$($publicHostName):$($port)/"
-		if ($expectedThumbprint -ne $machine.Resource.Thumbprint) {
+		if ($expectedThumbprint -ne $machine.Resource.EndPoint.Thumbprint) {
 			return $false
-		} elseif ($expectedUri -ne $machine.Resource.Uri) {
+		} elseif ($expectedUri -ne $machine.Resource.EndPoint.Uri) {
 			return $false
 		} else {
 			return $true		

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -69,7 +69,7 @@ powershell_script 'configure_tentacle_on_server' do
 	$publicHostName = '#{node['octopus']['tentacle']['publichostname']}'
 	$port = '#{node['octopus']['tentacle']['port']}'
 	$expectedEnvironments = @('#{node['octopus']['tentacle']['environment']}') -split ',' | %{$_.Trim()} |?{$_}
-	$expectedRoles = @('#{node['octopus']['tentacle']['role']}') -split ',' | %{$_.Trim()} |?{$_}
+	$expectedRoles = @('#{node['octopus']['tentacle']['role'].select{|k, v| v[:enable]}.map{|k,v| "#{k}"}.join(',')}') -split ',' | %{$_.Trim()} |?{$_}
 	$expectedThumbprint = Get-CurrentTentacleThumbprint
 	$expectedUri = "https://$($publicHostName):$($port)/"
 

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -38,9 +38,12 @@ powershell_script "configure_tentacle_on_server" do
 
 	Function Get-CurrentTentacleThumbprint
 	{
-		$subject = &'#{node['octopus']['tentacle']['install_dir']}\\Tentacle.exe' show-thumbprint --nologo
-		$result = $subject -creplace '((?:The thumbprint of this Tentacle is: )+)(?<field2>(?:[0-9a-zA-Z]+))', '${field2}'
-		return $result
+		$tentacleConfigPath ='#{node['octopus']['tentacle']['home']}\\Tentacle\\Tentacle.config'
+		$tentacleConfig = [xml] (Get-Content $tentacleConfigPath)
+		$thumbprintEntry = $tentacleConfig.'octopus-settings'.set|?{$_.key -eq 'Tentacle.CertificateThumbprint'}
+		$thumbprint = $thumbprintEntry.'#text'
+
+		return $thumbprint
 	}
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
@@ -120,9 +123,12 @@ powershell_script "configure_tentacle_on_server" do
 
 	Function Get-CurrentTentacleThumbprint
 	{
-		$subject = &'#{node['octopus']['tentacle']['install_dir']}\\Tentacle.exe' show-thumbprint --nologo
-		$result = $subject -creplace '((?:The thumbprint of this Tentacle is: )+)(?<field2>(?:[0-9a-zA-Z]+))', '${field2}'
-		return $result
+		$tentacleConfigPath ='#{node['octopus']['tentacle']['home']}\\Tentacle\\Tentacle.config'
+		$tentacleConfig = [xml] (Get-Content $tentacleConfigPath)
+		$thumbprintEntry = $tentacleConfig.'octopus-settings'.set|?{$_.key -eq 'Tentacle.CertificateThumbprint'}
+		$thumbprint = $thumbprintEntry.'#text'
+
+		return $thumbprint
 	}
 
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -56,7 +56,7 @@ powershell_script "configure_tentacle_on_server" do
 
 	$expectedEnvironmentIds =  @()
 	$expectedEnvironments | %{
-		$environment = Get-OctopusEnvironment -EnvironmentName $_
+		Try{$environment = Get-OctopusEnvironment -EnvironmentName $_}Catch{$environment = $null}
 
 		if (!($environment)) {
 			throw "There is no environment called $_"
@@ -64,7 +64,7 @@ powershell_script "configure_tentacle_on_server" do
 		$expectedEnvironmentIds += $environment.Id
 	}
 
-	$machine = Get-OctopusMachine -Name $machineName
+	Try{$machine = Get-OctopusMachine -Name $machineName}Catch{$machine = $null}
 
 	if ($machine) {
 		$machineChanged = $false
@@ -118,7 +118,7 @@ powershell_script "configure_tentacle_on_server" do
 	$machineName = '#{node['octopus']['tentacle']['name']}"'
 
 	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
-	$machine = Get-OctopusMachine -Name $machineName
+	Try{$machine = Get-OctopusMachine -Name $machineName}Catch{$machine=$null}
 
 	if ($machine) {
 		$expectedThumbprint = Get-CurrentTentacleThumbprint
@@ -161,7 +161,7 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 	$machineName = '#{node['octopus']['tentacle']['name']}"'
 	
 	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
-	$machine = Get-OctopusMachine -Name $machineName
+	Try{$machine = Get-OctopusMachine -Name $machineName}Catch{$machine = $null}
 
 	if ($machine -and $machine.Resource.HasLatestCalamari){
 		return $true

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -46,7 +46,7 @@ powershell_script "configure_tentacle_on_server" do
 	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
 	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
 	$machineName = '#{node['octopus']['tentacle']['name']}"'
-	$publicHostName = '#{node['octopus']['tentacle']['publichostname']}"'
+	$publicHostName = '#{node['octopus']['tentacle']['publichostname']}'
 	$port = '#{node['octopus']['tentacle']['port']}'
 	$expectedEnvironments = @('#{node['octopus']['tentacle']['environment']}') -split ',' | %{$_.Trim()} |?{$_}
 	$expectedRoles = @('#{node['octopus']['tentacle']['role']}') -split ',' | %{$_.Trim()} |?{$_}

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -8,7 +8,14 @@
 #
 
 # register the tentacle with octopus server
-powershell_script "register_tentacle" do
+
+octoposhPath = "#{Chef::Config['file_cache_path']}/octoposh.ps1"
+
+template octoposhPath do
+  source 'octoposh.ps1.erb'
+end
+
+powershell_script "configure_tentacle_locally" do
 	code <<-EOH
 	Set-Alias tentacle "#{node['octopus']['tentacle']['install_dir']}\\Tentacle.exe"
 	tentacle create-instance --instance "#{node['octopus']['tentacle']['name']}" --config "#{node['octopus']['tentacle']['home']}\\Tentacle\\Tentacle.config" --console
@@ -17,8 +24,149 @@ powershell_script "register_tentacle" do
 	tentacle configure --instance "#{node['octopus']['tentacle']['name']}" --app "#{node['octopus']['tentacle']['home']}\\Applications" --console
 	tentacle configure --instance "#{node['octopus']['tentacle']['name']}" --port "#{node['octopus']['tentacle']['port']}" --console
 	tentacle configure --instance "#{node['octopus']['tentacle']['name']}" --trust "#{node['octopus']['server']['thumbprint']}" --console
-	tentacle register-with --instance "#{node['octopus']['tentacle']['name']}" --name="#{node['octopus']['tentacle']['name']}" --publicHostName=#{node['ipaddress']} --server=#{node['octopus']['api']['uri']} --apiKey=#{node['octopus']['api']['key']} --role=#{node['octopus']['tentacle']['role']} --environment=#{node['octopus']['tentacle']['environment']} --comms-style TentaclePassive --console
 	tentacle service --instance "#{node['octopus']['tentacle']['name']}" --install --start --console
 	EOH
 	not_if {::File.exists?("#{node['octopus']['tentacle']['home']}\\Tentacle\\Tentacle.config")}
+end
+
+powershell_script "configure_tentacle_on_server" do
+	code <<-EOH
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	#{octoposhPath}
+
+	Function Get-CurrentTentacleThumbprint
+	{
+		$subject = &'#{node['octopus']['tentacle']['install_dir']}\\Tentacle.exe' show-thumbprint --nologo
+		$result = $subject -creplace '((?:The thumbprint of this Tentacle is: )+)(?<field2>(?:[0-9a-zA-Z]+))', '${field2}'
+		return $result
+	}
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$machineName = '#{node['octopus']['tentacle']['name']}"'
+	$publicHostName = '#{node['octopus']['tentacle']['publichostname']}"'
+	$port = '#{node['octopus']['tentacle']['port']}'
+	$expectedEnvironments = @('#{node['octopus']['tentacle']['environment']}') -split ',' | %{$_.Trim()} |?{$_}
+	$expectedRoles = @('#{node['octopus']['tentacle']['role']}') -split ',' | %{$_.Trim()} |?{$_}
+	$expectedThumbprint = Get-CurrentTentacleThumbprint
+
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
+
+	$expectedEnvironmentIds =  @()
+	$expectedEnvironments | %{
+		$environment = Get-OctopusEnvironment -EnvironmentName $_
+
+		if (!($environment)) {
+			throw "There is no environment called $_"
+		}
+		$expectedEnvironmentIds += $environment.Id
+	}
+
+	$machine = Get-OctopusMachine -Name $machineName
+
+	if ($machine) {
+		$machineChanged = $false
+
+		if ($expectedThumbprint -ne $machine.Resource.Thumbprint) {
+			write-host "Update machine to use new thumbprint $expectedThumbprint"
+			$machine.Resource.Thumbprint = $expectedThumbprint
+		}
+
+		if ($machineChanged) {
+			$machine | Update-OctopusResource
+		}
+	} else {
+		#Create an instance of a Machine Object
+		$machine = Get-OctopusResourceModel -Resource Machine
+
+		#Add mandatory properties to the object
+		$machine.name = $machineName #Display name of the machine on Octopus
+
+		$expectedEnvironmentIds | %{
+			$machine.EnvironmentIds.Add($_) #Environment where you want to register the machine
+		}
+
+		$expectedRoles | %{
+			$machine.Roles.Add($_) #Only one Role can be added at a time	
+		}
+
+		$machineEndpoint = New-Object Octopus.Client.Model.Endpoints.ListeningTentacleEndpointResource
+		$machine.EndPoint = $machineEndpoint
+		$machine.Endpoint.Uri = "https://$publicHostName:$port/" #URI of the machine.
+		$machine.Endpoint.Thumbprint = $expectedThumbprint #Thumbprint of the machine
+
+		New-OctopusResource -Resource $machine
+	}
+	EOH
+    not_if <<-EOH
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	#{octoposhPath}
+
+	Function Get-CurrentTentacleThumbprint
+	{
+		$subject = &'#{node['octopus']['tentacle']['install_dir']}\\Tentacle.exe' show-thumbprint --nologo
+		$result = $subject -creplace '((?:The thumbprint of this Tentacle is: )+)(?<field2>(?:[0-9a-zA-Z]+))', '${field2}'
+		return $result
+	}
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$machineName = '#{node['octopus']['tentacle']['name']}"'
+
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
+	$machine = Get-OctopusMachine -Name $machineName
+
+	if ($machine) {
+		$expectedThumbprint = Get-CurrentTentacleThumbprint
+		if ($expectedThumbprint -ne $machine.Resource.Thumbprint) {
+			return $false
+		} else {
+			return $true		
+		}
+	} else {
+		return $false
+	}
+    EOH	
+end
+
+powershell_script 'configure_tentacle_with_latest_calamari' do
+	guard_interpreter :powershell_script
+	code <<-EOH
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	#{octoposhPath}
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$machineName = '#{node['octopus']['tentacle']['name']}"'
+
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
+
+	Start-OctopusCalamariUpdate -MachineName $machineName -Wait
+	EOH
+	action :run
+    not_if <<-EOH
+	$ErrorActionPreference = 'Stop'
+	$ProgressPreference='SilentlyContinue'
+	Add-Type -Path '#{node['octopus']['tentacle']['install_dir']}\\Octopus.Client.dll'
+	#{octoposhPath}
+
+	$apikey = '#{node['octopus']['api']['key']}' # Get this from your profile
+	$octopusURI = '#{node['octopus']['api']['uri']}' # Your Octopus Server address
+	$machineName = '#{node['octopus']['tentacle']['name']}"'
+	
+	Set-OctopusConnectionInfo -URL $octopusURI -APIKey $apikey
+	$machine = Get-OctopusMachine -Name $machineName
+
+	if ($machine -and $machine.Resource.HasLatestCalamari){
+		return $true
+	} else {
+		return $false
+	}
+    EOH
 end

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -175,7 +175,6 @@ powershell_script 'configure_tentacle_with_latest_calamari' do
 
 	Start-OctopusCalamariUpdate -MachineName $machineName -Wait -Force
 	EOH3
-	action :run
     not_if <<-EOH4
 	$ErrorActionPreference = 'Stop'
 	$ProgressPreference='SilentlyContinue'

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -105,6 +105,14 @@ powershell_script 'configure_tentacle_on_server' do
 			$machine.Uri = $expectedUri
 			$machineChanged = $true
 		}
+		
+		$expectedEnvironmentIds | %{
+            if(-not $machine.EnvironmentIds.Contains($_))
+            {
+                $machine.Resource.EnvironmentIds.Add($_)
+                $machineChanged = $true
+            }
+        }
 
 		if ($machineChanged) {
 			$machine | Update-OctopusResource -Force

--- a/recipes/register_tentacle.rb
+++ b/recipes/register_tentacle.rb
@@ -94,7 +94,7 @@ powershell_script "configure_tentacle_on_server" do
 
 		$machineEndpoint = New-Object Octopus.Client.Model.Endpoints.ListeningTentacleEndpointResource
 		$machine.EndPoint = $machineEndpoint
-		$machine.Endpoint.Uri = "https://$publicHostName:$port/" #URI of the machine.
+		$machine.Endpoint.Uri = "https://$($publicHostName):$($port)/" #URI of the machine.
 		$machine.Endpoint.Thumbprint = $expectedThumbprint #Thumbprint of the machine
 
 		New-OctopusResource -Resource $machine

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -439,7 +439,7 @@ function Get-OctopusResourceModel
     Param
     (
         # Resource object model
-        [ValidateSet('Environment','Project','ProjectGroup','NugetFeed','LibraryVariableSet','Machine','Lifecycle')]         
+        [ValidateSet('Environment','Project','ProjectGroup','NugetFeed','LibraryVariableSet','Machine','Lifecycle','Team')]         
         [string]$Resource
     )
 
@@ -457,6 +457,7 @@ function Get-OctopusResourceModel
             'LibraryVariableSet' {$o = New-Object Octopus.Client.Model.LibraryVariableSetResource}
             'Machine' {$o = New-Object Octopus.Client.Model.MachineResource}
             'Lifecycle' {$o = New-Object Octopus.Client.Model.LifecycleResource}
+			'Team' {$o = New-Object Octopus.Client.Model.TeamResource}
         }      
     }
     End
@@ -703,16 +704,7 @@ function Get-OctopusMachine
                 Write-Progress -Activity "Getting info from machine: $($machine.name)" -status "$i of $($machines.count)" -percentComplete ($i / $machines.count*100)
                 Write-Verbose "[$($MyInvocation.MyCommand)] Getting info of Machine: $($Machine.name)"
 
-                $e = @() 
-
-                If($environments){
-                    $e = $environments | ?{$_.id -eq $machine.EnvironmentIds}
-                }
-
-                Else{
-                    $e = Get-OctopusResource "api/environments/$($machine.EnvironmentIds)" -header $c.header
-                }
-                
+                                
                 If($Machine.Endpoint.CommunicationStyle -eq 'TentacleActive'){$Style = 'Polling'}            
                 If($Machine.Endpoint.CommunicationStyle -eq 'TentaclePassive'){$Style = 'Listening'}               
 
@@ -722,7 +714,7 @@ function Get-OctopusMachine
                     Thumbprint = $machine.Thumbprint
                     URI = $machine.uri
                     IsDisabled = $machine.IsDisabled
-                    EnvironmentName = $e.name
+                    EnvironmentIds = {$machine.EnvironmentIds -split "`r`n"}.Invoke()
                     Roles = $machine.Roles
                     HasLatestCalamari = $machine.HasLatestCalamari
                     CommunicationStyle = $Style
@@ -788,6 +780,7 @@ function New-OctopusResource
             {$_.getType() -eq [Octopus.Client.Model.LibraryVariableSetResource]} {$res = 'LibraryVariableSets'}
             {$_.getType() -eq [Octopus.Client.Model.MachineResource]} {$res = 'Machines'}
             {$_.getType() -eq [Octopus.Client.Model.LifecycleResource]} {$res = 'Lifecycles'}
+			{$_.getType() -eq [Octopus.Client.Model.TeamResource]} {$res = 'Teams'}
             Default{Throw "Invalid object type: $($_.getType()) `nRun 'Get-OctopusResourceModel -ListAvailable' to get a list of the object types accepted by this cmdlet"}
         }
         Write-Verbose "[$($MyInvocation.MyCommand)] Creating an $($resource.GetType()) object"
@@ -1071,3 +1064,49 @@ function Start-OctopusHealthCheck
         return $List
     }
 }
+
+
+<#
+.Synopsis
+   Gets octopus team by name
+.DESCRIPTION
+   Gets octopus team by name
+.EXAMPLE
+   Get-OctopusTeam -Name "Local - foobar"
+#>
+
+function Get-OctopusTeam
+{
+    [CmdletBinding()]
+    [Alias()]
+    Param
+    (
+        # Environment name        
+        [alias("Name")]        
+        [string[]]$TeamName
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+        $list = @()
+        $i = 1
+    }
+    Process
+    {
+
+        If(!($TeamName -eq $null)){            
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting team by name: $TeamName" 
+            $list += $c.repository.Teams.FindByName($TeamName)            
+        }                       
+        
+    }
+    End
+    {
+        If($list.count -eq 0){
+            $list = $null
+        }
+        return $List
+    }
+}
+

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -714,7 +714,7 @@ function Get-OctopusMachine
                     Thumbprint = $machine.Thumbprint
                     URI = $machine.uri
                     IsDisabled = $machine.IsDisabled
-                    EnvironmentIds = {$machine.EnvironmentIds -split "`r`n"}.Invoke()
+                    EnvironmentIds = {$machine.EnvironmentIds -split "`r`n"}
                     Roles = $machine.Roles
                     HasLatestCalamari = $machine.HasLatestCalamari
                     CommunicationStyle = $Style

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -191,6 +191,108 @@ function New-OctopusConnection
 
 <#
 .Synopsis
+   Gets Octopus Tasks resources.
+   This cmdlet can be used to track the status of tasks such as Health checks, Backups, Deployments, etc. See parameter "Name" to see all the kind of tasks available.
+.DESCRIPTION
+   Long description
+.EXAMPLE
+   Get-OctopusTask Name Backup
+   Get all the Backup tasks of the server
+.EXAMPLE
+   Get-OctopusTask -name Health -status failed -After (Get-date).adddays(-7)
+   Get all the Health check tasks that failed over the past 7 days
+.EXAMPLE
+   Get-OctopusTask -TaskID "ServerTAsks-1234"
+   Get the server task with the id "ServerTasks-1234"
+.EXAMPLE
+   Get-OctopusTask -Name Backup -After 01/01/2015
+   Get all the Backup tasks 01/01/2015
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Get-OctopusTask
+{
+    [CmdletBinding()]
+    Param
+    (
+        # ID of task you want to get
+        [Alias('ID')]
+        [parameter(ParameterSetName = 'TaskId')]
+        [ValidateNotNullOrEmpty()]
+        [String[]]$TaskID,
+        
+        # Name of the task. Accepted values are: 'Backup','Delete','Health','Retention','Deploy','Upgrade','AdhocScript','TestEmail'
+        [ValidateSet('Backup','Delete','Health','Retention','Deploy','Upgrade','AdhocScript','TestEmail')]        
+        [String[]]$Name = '*',
+
+        # Document related to this task.
+        [Alias('DocumentID')]        
+        [string]$ResourceID = '*',
+
+        # Status of the task.
+        [Alias('Status')]
+        [ValidateSet('Success','TimedOut','Failed','Canceled','Executing','Canceling')]        
+        [string[]]$State = '*',
+
+        # Before date
+        [System.DateTimeOffset]$Before = [System.DateTimeOffset]::MaxValue,
+        
+        # After date
+        [System.DateTimeOffset]$After = [System.DateTimeOffset]::MinValue
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+        $list = @()
+    }
+    Process
+    {
+        If($TaskID){
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting tasks by ID"
+
+            $tasks = @()
+
+            foreach($t in $TaskID){
+                Write-Verbose "[$($MyInvocation.MyCommand)] Getting task id: $t"
+                $task = $c.repository.Tasks.Get($t)
+                If($task -eq $null){
+                    Write-Error "No tasks found with ID $t"
+                }
+                else {$tasks += $task}
+            }           
+            
+        }
+
+        elseif(($Name -ne '*') -or ($ResourceID -ne '*') -or ($State -ne '*') -or ($Before -ne [System.DateTimeOffset]::MaxValue) -or ($After -ne [System.DateTimeOffset]::MinValue)) {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting task by: `nName: $name`nResourceID: $resourceid`nState: $state`nBefore: $before`nAfter: $after"
+            $tasks = $c.repository.Tasks.FindMany({param($t) if( (($t.name -like $Name) -or ($t.name -in $name) ) -and (($t.state -like $State) -or ($t.state -in $State) )-and (($t.Arguments.values -contains $ResourceID) -or ($t.Arguments -like $ResourceID)) -and ($t.StartTime -ge $After) -and ($t.LastupdatedTime -le $Before)
+            ) {$true}})        
+        }
+
+        else{
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting all tasks"
+            $tasks = $c.repository.Tasks.FindAll()
+        }
+                
+        Write-Verbose "[$($MyInvocation.MyCommand)] Tasks found: $($Tasks.count)"
+
+        $list += $tasks       
+        
+    }
+    End
+    {        
+        If($list.count -eq 0){
+            $list = $null
+        }
+        return $List
+    }
+}
+
+<#
+.Synopsis
    Gets information about Octopus Environments
 .DESCRIPTION
    Gets information about Octopus Environments

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -374,7 +374,7 @@ function Get-OctopusEnvironment
                 
                     $t = $c.repository.Tasks.Get($d.links.task)
 
-                    $dev = (Invoke-WebRequest -Uri "$env:OctopusURL/api/events?regarding=$($d.Id)" -Method Get -Headers $c.header | ConvertFrom-Json).items | ? {$_.category -eq "DeploymentQueued"}
+                    $dev = (Invoke-WebRequest -UseBasicParsing -Uri "$env:OctopusURL/api/events?regarding=$($d.Id)" -Method Get -Headers $c.header | ConvertFrom-Json).items | ? {$_.category -eq "DeploymentQueued"}
 
                     $obj = [PSCustomObject]@{
                             ProjectName = ($dashboard.Projects | ?{$_.id -eq $d.projectId}).name

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -910,3 +910,164 @@ function Start-OctopusCalamariUpdate
     {
     }
 }
+
+<#
+.Synopsis
+   Starts a Health Check task on a specific set environment
+.DESCRIPTION
+   Starts a Health Check task on a specific set environment
+.EXAMPLE
+   Start-OctopusHealthCheck -Environment "Staging"
+   Starts a health on the environment "Staging"
+.EXAMPLE
+   Get-OctopusEnvironment -Name "Production" | Start-OctopusHealthCheck -force -Message "Health Check from powershell"
+   Starts a health check on the environment "Production"
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Start-OctopusHealthCheck
+{
+    [CmdletBinding(DefaultParameterSetName='Machine')]
+    Param
+    (
+        # The name of the environment/s on which you wanna start a health check. A task will start for each Environment listed on this parameter
+        [Parameter(Mandatory=$true,                   
+                   ParameterSetName='Environment')]
+        [string[]]$EnvironmentName,
+
+        [Parameter(Mandatory=$true,                   
+                   ParameterSetName='Machine')]
+        [string[]]$MachineName,      
+
+        # The message that will show up on the Octopus task. If a value is not passed to this parameter, a default message will be used
+        [string]$Message,
+
+        # Forces cmdlet to continue without prompting
+        [switch]$Force,
+
+        # Waits until the task is not on states "Queued" or "Executing"
+        [switch]$Wait,
+
+        # Timeout for [Wait] parameter in minutes. Default timeout is 2 minutes
+        [double]$Timeout = 2
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+        $list = @()
+    }
+    Process
+    {
+        If($PSCmdlet.ParameterSetName -eq 'Environment'){
+            foreach ($environment in $EnvironmentName){
+                Write-Verbose "[$($MyInvocation.MyCommand)] Processing environment: $environment"
+                Write-Verbose "[$($MyInvocation.MyCommand)] Getting machines from Environment: $environment"
+                $m = Get-OctopusMachine -EnvironmentName $Environment -ResourceOnly -ErrorAction Stop
+                Write-Verbose "[$($MyInvocation.MyCommand)] Found $($m.count) machines in environment $environment"                
+
+                $Machines += $m
+
+
+                If($Machines -ne $null){
+                    
+                    If(!$message){
+                        $message = "[API Generated] Check Health on Environment: $Environment"
+                    }
+
+                    If(!($Force)){
+                        If (!(Get-UserConfirmation -message "Are you sure you want to start a health check on the environment: $Environment")){
+                            Throw 'Canceled by user'
+                        }                    
+                    }
+            
+                    Write-Verbose "Starting Health check on Environment $environment which contains machines:"
+
+                    $Machines.name | %{Write-Verbose $_}
+
+                    $EnvironmentID = $Machines[0].environmentIDs[0]
+
+                    $Task = $c.repository.Tasks.ExecuteHealthCheck($Message,5,5,$environmentId,$Machines.Id)
+
+                    If($wait){
+
+                        $StartTime = Get-Date
+
+                        Do{
+                            $CurrentTime = Get-date
+                        
+                            $task = Get-OctopusTask -ID $task.id
+                        
+                            Start-Sleep -Seconds 2
+                        }Until (($task.state -notin ('Queued','executing')) -or ($CurrentTime -gt $StartTime.AddMinutes($Timeout)))
+
+                        Write-Verbose "Health task on environment $environment finished with status: $($task.state.tostring().toupper())"
+                    }
+                    $list += $Task
+                }
+
+                else{
+                    Write-Error 'No machines were found'
+                }
+            }
+        } Else {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Processing machine names: $MachineName"
+
+            foreach ($machineN in $MachineName){
+                Write-Verbose "[$($MyInvocation.MyCommand)] Getting machine: $machineN"
+                $m = Get-OctopusMachine -MachineName $machineN -ResourceOnly -ErrorAction Stop
+                Write-Verbose "[$($MyInvocation.MyCommand)] Found machine $machineN"         
+
+                $Machines += $m
+            }
+
+            If($Machines -ne $null){
+                If(!$message){
+                    $message = "[API Generated] Check Health on machines: $MachineName"
+                }
+
+                If(!($Force)){
+                    If (!(Get-UserConfirmation -message "Are you sure you want to start a health check on the machines: $MachineName")){
+                        Throw 'Canceled by user'
+                    }                    
+                }        
+
+                Write-Verbose "Starting Health check on machines: $MachineName"
+
+                $Machines.name | %{Write-Verbose $_}
+
+                $EnvironmentID = $Machines[0].environmentIDs[0]
+
+                $Task = $c.repository.Tasks.ExecuteHealthCheck($Message,5,5,$environmentId,$Machines.Id)
+
+                If($wait){
+
+                    $StartTime = Get-Date
+
+                    Do{
+                        $CurrentTime = Get-date
+                    
+                        $task = Get-OctopusTask -ID $task.id
+                    
+                        Start-Sleep -Seconds 2
+                    }Until (($task.state -notin ('Queued','executing')) -or ($CurrentTime -gt $StartTime.AddMinutes($Timeout)))
+
+                    Write-Verbose "Health task on machines $MachineName finished with status: $($task.state.tostring().toupper())"
+                }
+                $list += $Task                    
+            }
+            else{
+                Write-Error 'No machines were found'
+            }
+        }
+    }   
+    End
+    {
+        If($list.count -eq 0){
+            $list = $null
+        }
+        return $List
+    }
+}

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -714,7 +714,7 @@ function Get-OctopusMachine
                     Thumbprint = $machine.Thumbprint
                     URI = $machine.uri
                     IsDisabled = $machine.IsDisabled
-                    EnvironmentIds = {$machine.EnvironmentIds -split "`r`n"}
+                    EnvironmentIds = $machine.EnvironmentIds -split "`r`n"
                     Roles = $machine.Roles
                     HasLatestCalamari = $machine.HasLatestCalamari
                     CommunicationStyle = $Style

--- a/templates/default/octoposh.ps1.erb
+++ b/templates/default/octoposh.ps1.erb
@@ -1,0 +1,810 @@
+##Helper Functions. These wont get exported by the module, but will be available to be used by the exported cmdlets
+function Put-OctopusResource([string]$uri, [object]$resource) {
+    Invoke-RestMethod -Method Put -Uri "$env:OctopusURL/$uri" -Body $($resource | ConvertTo-Json -Depth 10) -Headers $c.header -Verbose:$false
+}
+
+function Get-OctopusResource([string]$uri, [object]$header) {
+    
+    return Invoke-RestMethod -Method Get -Uri "$env:OctopusURL/$uri" -Headers $header -Verbose:$false
+}
+
+function Get-UserConfirmation{ #Credits to http://www.peetersonline.nl/2009/07/user-confirmation-in-powershell/
+   
+           param([string]$title="Confirm`n",[string]$message)
+
+           $choiceYes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Answer Yes."
+
+           $choiceNo = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "Answer No."
+
+           $options = [System.Management.Automation.Host.ChoiceDescription[]]($choiceYes, $choiceNo)
+
+           $result = $host.ui.PromptForChoice($title, $message, $options, 1)
+
+           Switch ($result){
+              0{Return $true}
+ 
+              1{Return $false}
+           }
+        }
+
+#I'm quite sure there's an easier way to do this than using this ugly variable. Bet well...
+function Get-OctopusVariableScopeValue{    
+    param(
+        [parameter(Mandatory=$true)]
+        [Octopus.Client.Model.VariableSetResource]$Resource,
+
+        [parameter(Mandatory=$true)]
+        [String]$VariableName
+
+    )
+
+    $list = @()
+
+    $varscopes = ($Resource.Variables | ?{$_.name -eq $variableName}).scope
+
+    $scopevalues += $Resource.ScopeValues.Environments
+    $scopevalues += $Resource.ScopeValues.Machines
+    $scopevalues += $Resource.ScopeValues.Actions
+    
+    $varscopes.getenumerator() | %{        
+
+        $value = @()
+        If ($_.key -ne "Role"){
+            foreach ($v in $_.value){
+                $value += $scopevalues | ?{$_.Id -eq $v} | select -ExpandProperty name
+            } 
+        }
+
+        else{$value = $_.value}
+
+        $obj = [pscustomobject]@{
+            Scope = $_.key
+            value = $value
+        }
+        $list += $obj
+    }
+    
+   return $list
+}
+
+<#
+.Synopsis
+   Sets the current Octopus connection info (URL and API Key). 
+   
+   Highly recommended to call this function from $profile to avoid having to re-configure this on every session.
+.DESCRIPTION
+   Sets the current Octopus connection info (URL and API Key). 
+   
+   Highly recommended to call this function from $profile to avoid having to re-configure this on every session.
+.EXAMPLE
+   Set-OctopusConnectionInfo -URL "http://MyOctopus.AwesomeCompany.com" -API "API-7CH6XN0HHOU7DDEEUGKUFUR1K"
+   Set connection info with a specific API Key for an Octopus instance
+.LINK
+   Github project: ghttps://github.com/Dalmirog/Octoposh
+#>
+function Set-OctopusConnectionInfo
+{
+    [CmdletBinding()]
+    Param
+    (
+        # Octopus URL
+        [Parameter(Mandatory=$true)]
+        [string]$URL,
+
+        # Octopus API Key
+        [Parameter(Mandatory=$true)]
+        [string]$APIKey
+    )
+    Begin
+    {
+        
+    }
+    Process
+    {
+        $env:OctopusURL = $URL
+        $env:OctopusAPIKey = $APIKey        
+    }
+    End
+    {
+        Get-octopusConnectionInfo
+    }
+}
+
+<#
+.Synopsis
+   This function gets the data of the variables $env:OctopusURI and $env:OctopusAPI that are used by all the cmdlets of the Octoposh module
+.DESCRIPTION
+   This function gets the data of the variables $env:OctopusURI and $env:OctopusAPI that are used by all the cmdlets of the Octoposh module
+.EXAMPLE
+   Get-OctopusConnectionInfo
+   Get the current connection info. Its the same as getting the values of $env:OctopusURL and $Env:OctopusAPIKey
+.LINK
+   Github project: ghttps://github.com/Dalmirog/Octoposh
+#>
+function Get-OctopusConnectionInfo
+{
+    Begin
+    {
+        
+    }
+    Process
+    {
+        $properties = [ordered]@{
+            OctopusURL = $env:OctopusURL
+            OctopusAPIKey = $env:OctopusAPIKey
+        }
+
+        $o =  new-object psobject -Property $properties
+    }
+    End
+    {
+
+        return $o
+
+    }
+}
+
+<#
+.Synopsis
+   Creates an endpoint to connect to Octopus
+.DESCRIPTION
+   Creates an endpoint to connect to Octopus
+.EXAMPLE
+   $c = New-octopusconnection ; $c.repository.environments.findall()
+   Get all the environments on the Octopus instance using New-OctopusConnection and the Octopus.client
+.EXAMPLE
+   $c = New-OctopusConnection ; invoke-webrequest -header $c.header -uri http://Octopus.company.com/api/environments/all -method Get
+   Use the [Header] Member of the Object returned by New-OctopusConnection as a header to call the REST API using Invoke-WebRequest 
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function New-OctopusConnection
+{
+
+    Begin
+    {
+        If(([string]::IsNullOrEmpty($env:OctopusURL)) -or ([string]::IsNullOrEmpty($env:OctopusAPIKey)))
+        {
+            throw "At least one of the following variables does not have a value set: `$env:OctopusURL or `$env:OctopusAPIKey. Use Set-OctopusConnectionInfo to set these values"            
+        }
+    }
+    Process
+    {
+        $endpoint = new-object Octopus.Client.OctopusServerEndpoint "$($Env:OctopusURL)","$($env:OctopusAPIKey)"    
+        $repository = new-object Octopus.Client.OctopusRepository $endpoint                     
+
+        $properties = [ordered]@{
+            endpoint = $endpoint
+            repository = $repository
+            header = @{ "X-Octopus-ApiKey" = $env:OctopusAPIKey }
+        }
+
+        $output = New-Object psobject -Property $properties        
+    }
+    End
+    {
+        return $output
+    }
+}
+
+<#
+.Synopsis
+   Gets information about Octopus Environments
+.DESCRIPTION
+   Gets information about Octopus Environments
+.EXAMPLE
+   Get-OctopusEnvironment -name Production
+   Get info about the environment "Production"
+.EXAMPLE
+   Get-OctopusEnvironment -name "Dev*"
+   Get info about all the environments whose name starts with "Dev"
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Get-OctopusEnvironment
+{
+    [CmdletBinding()]
+    [Alias()]
+    Param
+    (
+        # Environment name        
+        [alias("Name")]
+        [Parameter(ValueFromPipelineByPropertyName = $true, Position=0)]
+        [string[]]$EnvironmentName,
+        
+        # When used the cmdlet will only return the plain Octopus resource object
+        [switch]$ResourceOnly
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+        $list = @()
+        $i = 1
+    }
+    Process
+    {
+
+        If(!($EnvironmentName -eq $null)){            
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting environments by name: $EnvironmentName" 
+            $environments = $c.repository.Environments.FindMany({param($env) if (($env.name -in $EnvironmentName) -or ($env.name -like $EnvironmentName)) {$true}})
+            
+            foreach($N in $EnvironmentName){
+                If(($n -notin $environments.name) -and !($environments.name -like $n)){
+                
+                    Write-Error "Environment not found: $n"
+                    #write-host "Environment not found: $n" -ForegroundColor Red
+                }
+            }
+
+        }
+
+        else{
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting all Environments" 
+            $environments = $c.repository.Environments.FindAll()
+        }
+
+        Write-Verbose "[$($MyInvocation.MyCommand)] Environments found: $($environments.count)" 
+
+        If ($ResourceOnly){
+            Write-Verbose "[$($MyInvocation.MyCommand)] [ResourceOnly] switch is on. Returning raw Octopus resource objects"
+            $list += $environments
+        }
+        Else{
+            $dashboard = Get-OctopusResource "/api/dashboard/dynamic" -header $c.header
+
+            foreach ($e in $environments){
+
+                Write-Progress -Activity "Getting info from Environment: $($E.name)" -status "$i of $($environments.count)" -percentComplete ($i / $environments.count*100)
+                Write-Verbose "[$($MyInvocation.MyCommand)] Getting info from environment $($e.name)"
+
+                $deployments = @()
+
+                $m = $c.repository.Machines.FindMany({param($ma) if ($e.id -in $ma.EnvironmentIds){$true}})
+
+                $dashboardItem = $dashboard.Items | ?{$e.Id -eq $_.EnvironmentId}
+
+                foreach($d in $dashboardItem){
+                
+                    $t = $c.repository.Tasks.Get($d.links.task)
+
+                    $dev = (Invoke-WebRequest -Uri "$env:OctopusURL/api/events?regarding=$($d.Id)" -Method Get -Headers $c.header | ConvertFrom-Json).items | ? {$_.category -eq "DeploymentQueued"}
+
+                    $obj = [PSCustomObject]@{
+                            ProjectName = ($dashboard.Projects | ?{$_.id -eq $d.projectId}).name
+                            EnvironmentName = ($dashboard.Environments | ?{$_.id -eq $d.EnvironmentId}).name
+                            ReleaseVersion = $d.ReleaseVersion
+                            State = $d.state
+                            CreatedBy = $dev.username
+                            StartTime = ($t.StartTime).datetime
+                            EndTime = ($t.CompletedTime).datetime
+
+                            }
+
+                    $deployments += $obj
+                }
+
+                $obj = [PSCustomObject]@{
+                                EnvironmentName = $e.name
+                                Id = $e.id
+                                Machines = $m
+                                LatestDeployment = $deployments
+                                Resource = $e
+                                                        
+                            }                                    
+                $list += $obj
+
+                $i++
+            }
+        }
+    }
+    End
+    {
+        If($list.count -eq 0){
+            $list = $null
+        }
+        return $List
+    }
+}
+
+
+<#
+.Synopsis
+   This cmdlet creates instances of Octopus Resource Objects
+.DESCRIPTION
+   This cmdlet creates instances of Octopus Resource Objects
+.EXAMPLE
+   $EnvironmentObj = Get-OctopusResourceModel -Resource Environment
+   Create an Environment Resource object 
+.EXAMPLE
+   $ProjectObj = Get-OctopusResourceModel -Resource Project
+   Create Project resource object
+.EXAMPLE
+   $pg = Get-OctopusResourceModel -Resource ProjectGroup
+   Create a Project Group resource object
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Get-OctopusResourceModel
+{
+    [CmdletBinding()]
+    Param
+    (
+        # Resource object model
+        [ValidateSet('Environment','Project','ProjectGroup','NugetFeed','LibraryVariableSet','Machine','Lifecycle')]         
+        [string]$Resource
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+    }
+    Process
+    {
+        Switch ($Resource){ 
+            'Environment' {$o = New-Object Octopus.Client.Model.EnvironmentResource}
+            'Project' {$o = New-Object Octopus.Client.Model.ProjectResource}
+            'ProjectGroup' {$o = New-Object Octopus.Client.Model.ProjectGroupResource}
+            'NugetFeed' {$o = New-Object Octopus.Client.Model.FeedResource}
+            'LibraryVariableSet' {$o = New-Object Octopus.Client.Model.LibraryVariableSetResource}
+            'Machine' {$o = New-Object Octopus.Client.Model.MachineResource}
+            'Lifecycle' {$o = New-Object Octopus.Client.Model.LifecycleResource}
+        }      
+    }
+    End
+    {
+        return $o
+    }
+}
+
+<#
+.Synopsis
+   Updates Octopus Resources on the database.   
+   This is an advanced cmdlet and all its examples involve multiple lines of code. Please check the advanced examples for a better reference: https://github.com/Dalmirog/OctoPosh/wiki/Modifying-Resources
+.DESCRIPTION
+   Updates Octopus Resources on the database.   
+   This is an advanced cmdlet and all its examples involve multiple lines of code. Please check the advanced examples for a better reference: https://github.com/Dalmirog/OctoPosh/wiki/Modifying-Resources
+.EXAMPLE
+    $pg = Get-OctopusProjectGroup -name SomeProjectName ; $pg.resource.name = "SomeOtherProjectName" ; $Pg | Update-OctopusResource
+    Update the Name of a ProjectGroup   
+.EXAMPLE
+    $machine = Get-OctopusMachine -MachineName "SQL_Production" ; $machine.resource.isdisabled = $true ; $machine | Update-OctopusResource
+    
+    Update the [IsDisabled] property of a machine to disable it
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Advanced Cmdlet Usage: https://github.com/Dalmirog/OctoPosh/wiki/Modifying-Resources
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Update-OctopusResource
+{
+    [CmdletBinding(DefaultParameterSetName='Update')]
+    Param
+    (
+        # Octopus resource object
+        [Parameter(Mandatory=$true,
+                   ValueFromPipelineByPropertyName=$true,
+                   ParameterSetName = 'Update',
+                   Position=0)]
+        [object[]]$Resource,
+
+        # Prints a list of the resource types accepted by the parameter $Resource.
+        [parameter(ParameterSetName = 'ListAcceptedTypes')]
+        [switch]$AcceptedTypes,
+        
+        # Forces cmdlet to continue without prompting
+        [switch]$Force
+    )
+
+    Begin
+    {
+        If($AcceptedTypes){
+
+            $types = ("Octopus.Client.Model.ProjectGroupResource",
+            "Octopus.Client.Model.ProjectResource",
+            "Octopus.Client.Model.EnvironmentResource",
+            "Octopus.Client.Model.MachineResource",
+            "Octopus.Client.Model.FeedResource",
+            "Octopus.Client.Model.VariableSetResource",
+            "Octopus.Client.Model.LifecycleResource")
+            
+            return $types
+        }
+
+        $c = New-OctopusConnection        
+    }
+    Process
+    {
+        Foreach ($r in $Resource){
+
+            if(!($Force)){
+                If (!(Get-UserConfirmation -message "Are you sure you want to update this resource? `n`n [$($R.GetType().tostring())] $($R.name)`n")){
+                    Throw 'Canceled by user'
+                }
+            }
+            switch ($r)
+            {
+                {$_.getType() -eq [Octopus.Client.Model.ProjectGroupResource]} {$ResourceType = 'ProjectGroups'}
+                {$_.getType() -eq [Octopus.Client.Model.ProjectResource]} {$ResourceType = 'Projects'}
+                {$_.getType() -eq [Octopus.Client.Model.EnvironmentResource]} {$ResourceType = 'Environments'}                
+                {$_.getType() -eq [Octopus.Client.Model.MachineResource]} {$ResourceType = 'Machines'}          
+                {$_.getType() -eq [Octopus.Client.Model.FeedResource]} {$ResourceType = 'Feeds'}                
+                {$_.getType() -eq [Octopus.Client.Model.VariableSetResource]} {$ResourceType = 'VariableSets'}
+                {$_.getType() -eq [Octopus.Client.Model.LifecycleResource]} {$ResourceType = 'Lifecycles'}
+                Default{Throw "Invalid object type: $($_.getType()) `nRun 'Update-OctopusResource -AcceptedTypes' to get a list of the object types accepted by this cmdlet"}                
+            }
+
+            Write-Verbose "[$($MyInvocation.MyCommand)] Updating $ResourceType`: $($r.name)"
+
+            Try{
+                $UpdatedObject = $c.repository.$ResourceType.Modify($r)
+            }
+            Catch{
+                Write-Error $_    
+            }
+        }
+    }
+    End
+    {
+        If(!$UpdatedObject){
+            $UpdatedObject = $null
+        }
+
+        return $UpdatedObject
+    }
+}
+
+<#
+.Synopsis
+   This cmdlet returns info about Octopus machines (tentacles)
+.DESCRIPTION
+   This cmdlet returns info about Octopus machines (tentacles)
+.EXAMPLE
+   Get-OctopusMachine -Name "Database_Prod"
+   Gets the machine with the name "Database_Prod"
+.EXAMPLE
+    Get-OctopusMachine -Name "*_Prod"
+    Gets all the machines which name is like "*_Prod"
+.EXAMPLE
+    Get-OctopusMachine -EnvironmentName "Staging","UAT"
+    Gets all the machines on the environments "Staging","UAT"
+.EXAMPLE
+    Get-OctopusMachine -URL "*:10933"
+    Gets all the machines with the string "*:10933" at the end of the URL
+.EXAMPLE
+    Get-OctopusMachine -Mode Listening
+    Gets all the machines registered in "Listening" mode. "Polling" is also a valid value
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Get-OctopusMachine
+{
+    [CmdletBinding(DefaultParameterSetName='Name')]
+    Param
+    (
+        # Machine name
+        [Alias('Name')]
+        [Parameter(ValueFromPipelineByPropertyName=$true,
+                   ParameterSetName = 'Name')]
+        [string[]]$MachineName,
+
+        # Environment name. Use to get all machines inside of an environment
+        [Alias('Environment')]
+        [Parameter(ValueFromPipelineByPropertyName=$true,
+                   ParameterSetName = 'Environment')]
+        [string[]]$EnvironmentName,
+
+        # URL of the machine
+        [Alias('URI')]
+        [Parameter(ParameterSetName = 'URL')]
+        [string[]]$URL,
+
+        # Communication style of the machine. Only values accepted are "Listening" and "Polling"
+        [Alias('Mode','TentacleMode')]
+        [ValidateSet('Listening','Polling')]         
+        [Parameter(ParameterSetName = 'CommunicationStyle')]
+        [string]$CommunicationStyle,
+
+        # When used the cmdlet will only return the plain Octopus resource object
+        [switch]$ResourceOnly
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+        $List = @()
+        $i = 1
+    }
+    Process
+    {
+        If(($PSCmdlet.ParameterSetName -eq 'Name') -and !([string]::IsNullOrEmpty($MachineName))) {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting Machines by $($PSCmdlet.ParameterSetName): $Machinename "
+            $Machines = $c.repository.Machines.FindMany({param($Mach) if ((($Mach.name -in $MachineName) -or ($Mach.name -like $MachineName))) {$true}})
+
+            foreach($n in $MachineName){
+                        If(($n -notin $Machines.name) -and !($Machines.name -like $n)){
+                            write-error "No Machines found with the name: $n"
+                            #write-host "No Machines found with the name: $n" -ForegroundColor Red
+                        }
+            }
+        }
+
+        elseIf($PSCmdlet.ParameterSetName -eq 'CommunicationStyle') {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting Machines by $($PSCmdlet.ParameterSetName): $CommunicationStyle"
+            If($CommunicationStyle -eq 'Polling'){$Style = 'TentacleActive'}            
+            elseIf($CommunicationStyle -eq 'Listening'){$Style = 'TentaclePassive'}
+
+            $Machines = $c.repository.Machines.FindMany({param($Mach) if ($Mach.Endpoint.CommunicationStyle -eq $Style){$true}})
+
+            If($Machines -eq $null){
+                Write-Error "No Machines found with CommunicationStyle: $($Style)"
+                #write-host "No Machines found with CommunicationStyle: $($Style)" -ForegroundColor Red
+            }
+        }
+
+        elseIf(($PSCmdlet.ParameterSetName -eq 'URL') -and (!([string]::IsNullOrEmpty($URL)))) {
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting Machines by $($PSCmdlet.ParameterSetName): $URL"
+            $Machines = $c.repository.Machines.FindMany({param($Mach) if ((($Mach.URI -in $URL) -or ($Mach.URI -like $URL))) {$true}})
+
+            foreach($U in $URL){
+                If(($U -notin $Machines.URI) -and !($Machines.URI -like $U)){
+                    write-error "No Machines found with the URL: $U"
+                    #write-host "No Machines found with the URL: $U" -ForegroundColor Red
+                }
+            }
+        }
+
+        elseIf(($PSCmdlet.ParameterSetName -eq 'Environment') -and !([string]::IsNullOrEmpty($EnvironmentName))) {
+            
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting Machines by $($PSCmdlet.ParameterSetName): $EnvironmentName"
+            $machines = @()
+
+            $environments = Get-OctopusEnvironment $EnvironmentName -ResourceOnly
+
+            Foreach($env in $environments){
+
+                $envmachines = $c.repository.Environments.GetMachines($env)
+
+                If($envmachines){
+                    Write-Verbose "[$($MyInvocation.MyCommand)] [ResourceOnly] switch is on. Returning raw Octopus resource objects"
+                    $machines += $envmachines            
+                }
+
+                Else{
+                    Write-Error "No machines were found on Environment: $($env.name)"
+                    #Write-host "No machines were found on Environment: $($env.name)" -ForegroundColor Red
+                }        
+            }    
+        }
+
+        else{        
+            Write-Verbose "[$($MyInvocation.MyCommand)] Getting all the Machines"
+            $Machines = $c.repository.Machines.FindAll()
+        }
+
+        Write-Verbose "[$($MyInvocation.MyCommand)] Machines found: $($Machines.count)"
+
+        If($ResourceOnly){
+            $list += $Machines
+        }
+
+        else{            
+            foreach ($machine in $Machines){                
+                Write-Progress -Activity "Getting info from machine: $($machine.name)" -status "$i of $($machines.count)" -percentComplete ($i / $machines.count*100)
+                Write-Verbose "[$($MyInvocation.MyCommand)] Getting info of Machine: $($Machine.name)"
+
+                $e = @() 
+
+                If($environments){
+                    $e = $environments | ?{$_.id -eq $machine.EnvironmentIds}
+                }
+
+                Else{
+                    $e = Get-OctopusResource "api/environments/$($machine.EnvironmentIds)" -header $c.header
+                }
+                
+                If($Machine.Endpoint.CommunicationStyle -eq 'TentacleActive'){$Style = 'Polling'}            
+                If($Machine.Endpoint.CommunicationStyle -eq 'TentaclePassive'){$Style = 'Listening'}               
+
+                $obj = [PSCustomObject]@{
+                    MachineName = $machine.Name
+                    MachineID = $machine.Id
+                    Thumbprint = $machine.Thumbprint
+                    URI = $machine.uri
+                    IsDisabled = $machine.IsDisabled
+                    EnvironmentName = $e.name
+                    Roles = $machine.Roles
+                    HasLatestCalamari = $machine.HasLatestCalamari
+                    CommunicationStyle = $Style
+                    Status = $machine.Status
+                    StatusSummary = $machine.StatusSummary
+                    Resource = $machine
+                }
+
+                $list += $obj
+                
+                $i++
+            }
+        }
+    }
+    End
+    {
+        If($list.count -eq 0){
+            $list = $null
+        }
+        return $List 
+    }
+}
+
+<##
+.Synopsis
+   Creates a new Octopus Resource out of a resource Object.
+   This is an advanced cmdlet and all its examples involve multiple lines of code. Please check the advanced examples for a better reference: https://github.com/Dalmirog/OctoPosh/wiki/Advanced-Examples
+.DESCRIPTION
+   Creates a new Octopus Resource out of a resource Object.
+   This is an advanced cmdlet and all its examples involve multiple lines of code. Please check the advanced examples for a better reference: https://github.com/Dalmirog/OctoPosh/wiki/Advanced-Examples
+.EXAMPLE
+   $pg = Get-OctopusResourceModel -Resource ProjectGroup ; $pg.name = "NewProjectGroup" ; New-OctopusResource -Resource $pg   
+   Create a new Project Group called "NewProjectGroup" on Octopus
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function New-OctopusResource
+{
+    [CmdletBinding()]
+    Param
+    (
+        # Resource Object
+        [Parameter(Mandatory=$true,
+                   ValueFromPipeline=$true,
+                   Position=0)]
+        $Resource
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+    }
+    Process
+    {
+        switch ($Resource)
+        {
+            {$_.getType() -eq [Octopus.Client.Model.ProjectGroupResource]} {$res = 'ProjectGroups'}
+            {$_.getType() -eq [Octopus.Client.Model.ProjectResource]} {$res = 'Projects'}
+            {$_.getType() -eq [Octopus.Client.Model.EnvironmentResource]} {$res = 'Environments'}
+            {$_.getType() -eq [Octopus.Client.Model.FeedResource]} {$res = 'Feeds'}
+            {$_.getType() -eq [Octopus.Client.Model.LibraryVariableSetResource]} {$res = 'LibraryVariableSets'}
+            {$_.getType() -eq [Octopus.Client.Model.MachineResource]} {$res = 'Machines'}
+            {$_.getType() -eq [Octopus.Client.Model.LifecycleResource]} {$res = 'Lifecycles'}
+            Default{Throw "Invalid object type: $($_.getType()) `nRun 'Get-OctopusResourceModel -ListAvailable' to get a list of the object types accepted by this cmdlet"}
+        }
+        Write-Verbose "[$($MyInvocation.MyCommand)] Creating an $($resource.GetType()) object"
+        $newres = $c.repository.$res.Create($resource)
+
+    }
+    End
+    {
+        return $newres
+    }
+}
+
+<#
+.Synopsis
+   Starts a "Calamari Update" taks on a machine or set of machines inside of an environment
+.DESCRIPTION
+   Starts a "Calamari Update" taks on a machine or set of machines inside of an environment
+.EXAMPLE
+   Start-OctopusCalamariUpdate -Environment "Staging"
+   Starts a "Calamari Update" task for all the machines inside of the environment "Staging"
+.EXAMPLE
+   Start-OctopusCalamariUpdate -MachineName "NY-DB1"
+   Starts a "Calamari Update" task on the machine "NY-DB1"
+.LINK
+   Github project: https://github.com/Dalmirog/Octoposh
+   Wiki: https://github.com/Dalmirog/OctoPosh/wiki
+   QA and Cmdlet request: https://gitter.im/Dalmirog/OctoPosh#initial
+#>
+function Start-OctopusCalamariUpdate
+{
+    [CmdletBinding(DefaultParameterSetName='Machine')]    
+    Param
+    (
+        # The name of the environment/s on which you wanna start a health check. A task will start for each Environment listed on this parameter
+        [Parameter(Mandatory=$true,                   
+                   ParameterSetName='Environment')]
+        [string[]]$EnvironmentName,
+
+        [Parameter(Mandatory=$true,                   
+                   ParameterSetName='Machine')]
+        [string[]]$MachineName,
+
+        # The message that will show up on the Octopus task. If a value is not passed to this parameter, a default message will be used
+        [string]$Message,
+
+        # Forces cmdlet to continue without prompting
+        [switch]$Force,
+
+        # Waits until the task is not on states "Queued" or "Executing"
+        [switch]$Wait,
+
+        # Timeout for [Wait] parameter in minutes. Default timeout is 2 minutes
+        [double]$Timeout = 2
+    )
+
+    Begin
+    {
+        $c = New-OctopusConnection
+        $machines = @()
+        $list = @()
+    }
+    Process
+    {
+        If($PSCmdlet.ParameterSetName -eq 'Environment'){
+            foreach ($environment in $EnvironmentName){
+            
+                Write-Verbose "[$($MyInvocation.MyCommand)] Getting machines from Environment: $environment"
+
+                $m = Get-OctopusMachine -EnvironmentName $Environment -ResourceOnly -ErrorAction Stop
+                
+                Write-Verbose "[$($MyInvocation.MyCommand)] Found $($m.count) machines in environment $environment"                
+
+                $Machines += $m
+            }
+        }
+
+        Else{
+            $machines = Get-OctopusMachine -MachineName $MachineName -ResourceOnly -ErrorAction Stop
+        }
+
+        If(!$message -and $PSCmdlet.ParameterSetName -eq 'Machine'){
+            $message = "[API Generated] Starting 'Calamari Update' task on Machines: $($machines.name)"
+        }
+
+        elseIf(!$message -and $PSCmdlet.ParameterSetName -eq 'Environment'){
+            $message = "[API Generated] Starting 'Calamari Update' task on Environments: $EnvironmentName"
+        }
+
+        If(!($Force)){
+            If (!(Get-UserConfirmation -message "Are you sure you want to start a health check on the environment: $Environment")){
+                Throw 'Canceled by user'
+            }
+        }
+        If($machines.count -ne 0){
+            $task = $c.repository.Tasks.ExecuteCalamariUpdate($Message,$machines.id)
+        }
+        If($wait){
+
+            $StartTime = Get-Date
+
+            Do{
+                $CurrentTime = Get-date
+                    
+                $task = Get-OctopusTask -ID $task.id
+                    
+                Start-Sleep -Seconds 2
+
+                Write-Verbose "[Get-OctopusTask] Task state is: $($task.state)"
+            }Until (($task.state -notin ('Queued','executing')) -or ($CurrentTime -gt $StartTime.AddMinutes($Timeout)))
+
+            Write-Verbose "[Get-OctopusTask] Task finished or cmdlet timed out. Last task status: $($task.state.tostring().toupper())"
+            return $task
+        }
+
+        else{
+            return $task
+        }        
+    }   
+    End
+    {
+    }
+}


### PR DESCRIPTION
When setting up the Tentacle on the client, we want to update the Tentacle settings on Octopus server. So Tentacle will be ready as a deployment target as soon as recipe has run.

If Tentacle changes certificate, re-running will configure Octopus server for new settings.
